### PR TITLE
Fixed a bug in attribute reader

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -6,10 +6,11 @@ import (
 )
 
 type NTFSContext struct {
-	DiskReader io.ReaderAt
-	Boot       *NTFS_BOOT_SECTOR
-	RootMFT    *MFT_ENTRY
-	Profile    *NTFSProfile
+	DiskReader  io.ReaderAt
+	Boot        *NTFS_BOOT_SECTOR
+	RootMFT     *MFT_ENTRY
+	Profile     *NTFSProfile
+	ClusterSize int64
 }
 
 func (self *NTFSContext) GetMFT(id int64) (*MFT_ENTRY, error) {

--- a/parser/easy.go
+++ b/parser/easy.go
@@ -37,6 +37,8 @@ func GetNTFSContext(image io.ReaderAt, offset int64) (*NTFSContext, error) {
 		return nil, err
 	}
 
+	ntfs.ClusterSize = ntfs.Boot.ClusterSize()
+
 	mft_reader, err := BootstrapMFT(ntfs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Some files have an initialized_size < actual_size which implies the
runlist should be padded after initialized_size with 0s.