### PR TITLE
Added command to dump out highlight from an $MFT file.

### DIFF
--- a/bin/mft.go
+++ b/bin/mft.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"www.velocidex.com/golang/go-ntfs/parser"
+)
+
+var (
+	mft_command = app.Command(
+		"mft", "Process a raw $MFT file.")
+
+	mft_command_file_arg = mft_command.Arg(
+		"file", "The $MFT file to process",
+	).Required().File()
+)
+
+const (
+	mft_entry_size int64 = 0x400
+)
+
+func doMFT() {
+	reader, _ := parser.NewPagedReader(*mft_command_file_arg, 1024, 10000)
+	st, err := (*mft_command_file_arg).Stat()
+	kingpin.FatalIfError(err, "Can not open MFT file")
+
+	for item := range parser.ParseMFTFile(reader, st.Size(), 0x1000, 0x400) {
+		serialized, err := json.MarshalIndent(item, " ", " ")
+		kingpin.FatalIfError(err, "Marshal")
+
+		fmt.Println(string(serialized))
+	}
+}
+
+func init() {
+	command_handlers = append(command_handlers, func(command string) bool {
+		switch command {
+		case "mft":
+			doMFT()
+		default:
+			return false
+		}
+		return true
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/davecgh/go-spew v1.1.1
+	github.com/hashicorp/golang-lru v0.5.3
 	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc
 	github.com/sebdah/goldie v0.0.0-20180424091453-8784dd1ab561

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
+github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc h1:rQ1O4ZLYR2xXHXgBCCfIIGnuZ0lidMQw2S5n1oOv+Wg=

--- a/parser/boot.go
+++ b/parser/boot.go
@@ -31,6 +31,10 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 	// value is the magic and the rest are fixup values.
 	fixup_offset := mft.Offset + int64(mft.Fixup_offset())
 	fixup_count := int64(mft.Fixup_count())
+	if fixup_count == 0 {
+		return nil, errors.New("Invalid fixup")
+	}
+
 	fixup_table := make([]byte, fixup_count*2)
 	_, err := mft.Reader.ReadAt(fixup_table, fixup_offset)
 	if err != nil {

--- a/parser/context.go
+++ b/parser/context.go
@@ -11,6 +11,15 @@ type NTFSContext struct {
 	RootMFT     *MFT_ENTRY
 	Profile     *NTFSProfile
 	ClusterSize int64
+	RecordSize  int64
+}
+
+func (self *NTFSContext) GetRecordSize() int64 {
+	if self.RecordSize == 0 {
+		self.RecordSize = self.Boot.RecordSize()
+	}
+
+	return self.RecordSize
 }
 
 func (self *NTFSContext) GetMFT(id int64) (*MFT_ENTRY, error) {
@@ -21,7 +30,7 @@ func (self *NTFSContext) GetMFT(id int64) (*MFT_ENTRY, error) {
 	}
 
 	disk_mft := self.Profile.MFT_ENTRY(self.RootMFT.Reader,
-		self.Boot.RecordSize()*id)
+		self.GetRecordSize()*id)
 
 	// Fixup the entry.
 	mft_reader, err := FixUpDiskMFTEntry(disk_mft)


### PR DESCRIPTION
This allows one to parse all the mft entries from the single $MFT file
itself without needing the entire image.

One can then go back to the image and extract the mft entries of
interest only.