### PR TITLE
Fix a potential out of range bug when reading on 32-bit systems

### DIFF
--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -370,9 +370,9 @@ func (self *RunReader) readFromARun(
 		}
 
 	} else {
-		to_read := int(run.Length*run.ClusterSize) - run_offset
-		if len(buf) < to_read {
-			to_read = len(buf)
+		to_read := run.Length*run.ClusterSize - int64(run_offset)
+		if int64(len(buf)) < to_read {
+			to_read = int64(len(buf))
 		}
 
 		// Run contains data - read it


### PR DESCRIPTION
Fixes a bug where a 64 bit value was casted to int, potentially
resulting in a negative value that would then cause a panic
due to it being used in a slice expression.

To reproduce: Try reading a very large file (e.g. pagefile.sys) on a 32-bit Windows.