### PR TITLE
Fix a possible panic with corrupt MFT entries.

### DIFF
--- a/parser/boot.go
+++ b/parser/boot.go
@@ -54,7 +54,8 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 	sector_idx := 0
 	for idx := 2; idx < len(fixup_table); idx += 2 {
 		fixup_offset := (sector_idx+1)*512 - 2
-		if buffer[fixup_offset] != fixup_magic[0] ||
+		if fixup_offset + 1 >= len(buffer) ||
+			buffer[fixup_offset] != fixup_magic[0] ||
 			buffer[fixup_offset+1] != fixup_magic[1] {
 			return nil, errors.New(fmt.Sprintf("Fixup error with MFT %d",
 				mft.Record_number()))


### PR DESCRIPTION
Fix a bug where a corrupt MFT entry could lead to a panic from
an out of bounds array access.