### PR TITLE
fix: Always return an error or some content from LimitedReader

### DIFF
--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -32,6 +32,12 @@ func (self LimitedReader) ReadAt(buff []byte, off int64) (int, error) {
 
 	if off+int64(n) > self.N {
 		n = int(self.N - off)
+		if n < 0 {
+			n = 0
+		}
+		if err == nil {
+			err = io.EOF
+		}
 	}
 
 	return n, err


### PR DESCRIPTION
The contract from io.ReaderAt requires that err != nil if less
than len(p) bytes are returned, and that 0 <= n <= len(p).
LimitedReader currently fulfills neither requirements:
 - For off > self.N, n is negative.
 - For off + n > self.N, n is limited and thus n < len(p),
   but no error is returned.

Add additional cases to catch these contract violations.