### PR TITLE
MFT analysis bug fix

### DIFF
--- a/parser/easy.go
+++ b/parser/easy.go
@@ -251,6 +251,13 @@ func Stat(ntfs *NTFSContext, node_mft *MFT_ENTRY) []*FileInfo {
 
 		add_extra_names(info, ads)
 
+		// Since ADS are actually data streams they can not be
+		// directories themselves. The underlying file info will still
+		// be a directory.
+		if ads != "" {
+			info.IsDir = false
+		}
+
 		result = append(result, info)
 	}
 

--- a/parser/mft.go
+++ b/parser/mft.go
@@ -453,6 +453,7 @@ func ParseMFTFile(
 			var si *STANDARD_INFORMATION
 			var size int64
 			ads := []string{}
+			ads_sizes := []int64{}
 			si_flags := ""
 
 			for _, attr := range mft_entry.EnumerateAttributes(ntfs) {
@@ -467,6 +468,7 @@ func ParseMFTFile(
 					attr_name := attr.Name()
 					if attr_name != "" {
 						ads = append(ads, attr_name)
+						ads_sizes = append(ads_sizes, int64(attr.Size()))
 					}
 
 				case "$FILE_NAME":
@@ -533,7 +535,7 @@ func ParseMFTFile(
 			}
 
 			// Duplicate ADS names so we can easily search on them.
-			for _, ads_name := range ads {
+			for idx, ads_name := range ads {
 				new_row := row.Copy()
 
 				file_names := []string{}
@@ -546,6 +548,7 @@ func ParseMFTFile(
 				new_row.FileNames = file_names
 				new_row.IsDir = false
 				new_row.ads_name = ads_name
+				new_row.FileSize = ads_sizes[idx]
 
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
When MFT parsing encounters an ADS it duplicates the row - the ADS row
should
1. Be considered as a file not a directory (IsDir = false)
2. Size should reflect the size of the ADS not the host entry.