### PR TITLE
Purge ntfs context caches to ensure each watch USN pass has new data

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -43,11 +43,17 @@ func (self *NTFSContext) Close() {
 		fmt.Println(self.mft_entry_lru.DebugString())
 		fmt.Println(self.full_path_lru.DebugString())
 	}
-	self.mft_entry_lru.Purge()
+	self.Purge()
 }
 
 func (self *NTFSContext) Purge() {
 	self.mft_entry_lru.Purge()
+
+	// Try to flush our reader if possible
+	flusher, ok := self.DiskReader.(Flusher)
+	if ok {
+		flusher.Flush()
+	}
 }
 
 func (self *NTFSContext) GetRecordSize() int64 {

--- a/parser/reader.go
+++ b/parser/reader.go
@@ -78,8 +78,12 @@ func (self *PagedReader) ReadAt(buf []byte, offset int64) (int, error) {
 }
 
 func (self *PagedReader) Flush() {
-	DebugPrint("Closing page reader\n")
 	self.lru.Purge()
+
+	flusher, ok := self.reader.(Flusher)
+	if ok {
+		flusher.Flush()
+	}
 }
 
 func NewPagedReader(reader io.ReaderAt, pagesize int64, cache_size int) (*PagedReader, error) {


### PR DESCRIPTION
This resulted in a bug where watch_usn() was unable to emit new rows
after a while.