### PR TITLE
Added error reporting when reconstructing the path

### DIFF
--- a/bin/test_filename.go
+++ b/bin/test_filename.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"www.velocidex.com/golang/go-ntfs/parser"
+)
+
+var (
+	test_fn_command = app.Command(
+		"test_filename", "Test file path reconstruction by comparing with TSK.")
+
+	test_fn_command_file_arg = test_fn_command.Arg(
+		"file", "The image file to inspect",
+	).Required().File()
+
+	test_fn_command_ffind_path = test_fn_command.Flag(
+		"ffind_path", "Path to the ffind binary").
+		Default("ffind").String()
+
+	test_fn_command_start_id = test_fn_command.Flag(
+		"start", "First MFT ID to test").Default("0").Int64()
+)
+
+func calcFilenameWithTSK(inode string) (string, error) {
+	command := exec.Command(*test_fn_command_ffind_path,
+		(*test_fn_command_file_arg).Name(), inode)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+func doTestFn() {
+	reader, err := parser.NewPagedReader(*test_fn_command_file_arg, 1024, 10000)
+	kingpin.FatalIfError(err, "Can not open MFT file")
+
+	ntfs_ctx, err := parser.GetNTFSContext(reader, 0)
+	kingpin.FatalIfError(err, "Can not open filesystem")
+
+	mft_stream, err := parser.GetDataForPath(ntfs_ctx, "$MFT")
+	kingpin.FatalIfError(err, "Can not open filesystem")
+
+	for i := int64(*test_command_start_id); i < parser.RangeSize(mft_stream)/ntfs_ctx.RecordSize; i++ {
+		mft_entry, err := ntfs_ctx.GetMFT(i)
+		if err != nil {
+			continue
+		}
+
+		full_path, err := parser.GetFullPath(ntfs_ctx, mft_entry)
+		if err != nil {
+			fmt.Printf("Error %v: %v\n", i, err)
+			continue
+		}
+
+		if *verbose_flag {
+			fmt.Printf("%v: %v\n", i, full_path)
+		}
+
+		tsk_path, err := calcFilenameWithTSK(fmt.Sprintf("%v", i))
+		if err != nil {
+			fmt.Printf("go-ntfs Error %v: %v\n", i, err)
+		}
+
+		if *verbose_flag {
+			fmt.Printf("tsk_path %v: %v\n", i, tsk_path)
+		}
+
+		if tsk_path != full_path {
+			fmt.Printf("**** ERROR %v: %v != %v\n", i, tsk_path, full_path)
+		}
+
+	}
+}
+
+func init() {
+	command_handlers = append(command_handlers, func(command string) bool {
+		switch command {
+		case test_fn_command.FullCommand():
+			doTestFn()
+		default:
+			return false
+		}
+		return true
+	})
+}

--- a/parser/boot.go
+++ b/parser/boot.go
@@ -7,6 +7,11 @@ import (
 	"io"
 )
 
+var (
+	EntryTooShortError = errors.New("EntryTooShortError")
+	ShortReadError     = errors.New("ShortReadError")
+)
+
 func (self *NTFS_BOOT_SECTOR) ClusterSize() int64 {
 	return int64(self._cluster_size()) * int64(self.Sector_size())
 }
@@ -31,10 +36,22 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 
 	// Read the entire MFT entry into the buffer and then apply
 	// the fixup table. (Maxsize uint16)
-	buffer := make([]byte, CapUint16(mft.Mft_entry_allocated(), MAX_MFT_ENTRY_SIZE))
-	_, err := mft.Reader.ReadAt(buffer, mft.Offset)
+	mft_allocated_size := mft.Mft_entry_allocated()
+	allocated_len := CapUint16(mft_allocated_size, MAX_MFT_ENTRY_SIZE)
+
+	// MFT should be a reasonable size - if it is too small it is
+	// probably not valid.
+	if allocated_len < 0x100 {
+		return nil, EntryTooShortError
+	}
+
+	buffer := make([]byte, allocated_len)
+	n, err := mft.Reader.ReadAt(buffer, mft.Offset)
 	if err != nil {
 		return nil, err
+	}
+	if n < int(allocated_len) {
+		return nil, ShortReadError
 	}
 
 	// The fixup table is an array of 2 byte values. The first
@@ -45,10 +62,14 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 		return bytes.NewReader(buffer), nil
 	}
 
-	fixup_table := make([]byte, CapInt64(fixup_count*2, MAX_MFT_ENTRY_SIZE))
-	_, err = mft.Reader.ReadAt(fixup_table, fixup_offset)
+	fixup_table_len := CapInt64(fixup_count*2, int64(allocated_len))
+	fixup_table := make([]byte, fixup_table_len)
+	n, err = mft.Reader.ReadAt(fixup_table, fixup_offset)
 	if err != nil {
 		return nil, err
+	}
+	if n < int(fixup_table_len) {
+		return nil, errors.New("Short read")
 	}
 
 	fixup_magic := []byte{fixup_table[0], fixup_table[1]}

--- a/parser/context.go
+++ b/parser/context.go
@@ -13,6 +13,8 @@ type NTFSContext struct {
 	RootMFT    *MFT_ENTRY
 	Profile    *NTFSProfile
 
+	MaxDirectoryDepth int
+
 	ClusterSize int64
 
 	mu         sync.Mutex
@@ -30,10 +32,11 @@ func newNTFSContext(image io.ReaderAt, name string) *NTFSContext {
 	full_path_cache, _ := NewLRU(100000, nil, name+"FullPath")
 	mft_cache, _ := NewLRU(10000, nil, name)
 	return &NTFSContext{
-		DiskReader:    image,
-		Profile:       NewNTFSProfile(),
-		mft_entry_lru: mft_cache,
-		full_path_lru: full_path_cache,
+		DiskReader:        image,
+		MaxDirectoryDepth: 10,
+		Profile:           NewNTFSProfile(),
+		mft_entry_lru:     mft_cache,
+		full_path_lru:     full_path_cache,
 	}
 }
 

--- a/parser/mft.go
+++ b/parser/mft.go
@@ -344,9 +344,10 @@ type MFTHighlight struct {
 	LogFileSeqNum uint64
 
 	// Hold on to these for delayed lazy evaluation.
-	ntfs_ctx  *NTFSContext
-	mft_entry *MFT_ENTRY
-	ads_name  string
+	ntfs_ctx   *NTFSContext
+	mft_entry  *MFT_ENTRY
+	ads_name   string
+	components []string
 }
 
 // Copy the struct safely replacing the mutex
@@ -407,13 +408,16 @@ func (self *MFTHighlight) FileName() string {
 }
 
 func (self *MFTHighlight) Components() []string {
-	components, _ := GetComponents(self.ntfs_ctx, self.mft_entry)
-
-	if self.ads_name != "" {
-		return setADS(components, self.ads_name)
+	if len(self.components) > 0 {
+		return self.components
 	}
 
-	return components
+	self.components, _ = GetComponents(self.ntfs_ctx, self.mft_entry)
+	if self.ads_name != "" {
+		return setADS(self.components, self.ads_name)
+	}
+
+	return self.components
 }
 
 func ParseMFTFile(

--- a/parser/reader.go
+++ b/parser/reader.go
@@ -52,12 +52,15 @@ func (self *PagedReader) ReadAt(buf []byte, offset int64) (int, error) {
 				self.lru.Len())
 			// Read this page into memory.
 			page_buf = make([]byte, self.pagesize)
-			_, err := self.reader.ReadAt(page_buf, page)
+			n, err := self.reader.ReadAt(page_buf, page)
 			if err != nil && err != io.EOF {
 				return buf_idx, err
 			}
 
-			self.lru.Add(int(page), page_buf)
+			// Only cache full pages.
+			if n == int(self.pagesize) {
+				self.lru.Add(int(page), page_buf)
+			}
 		} else {
 			self.Hits += 1
 			page_buf = cached_page_buf.([]byte)

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -49,8 +49,7 @@ func getComponents(ntfs *NTFSContext, mft_entry *MFT_ENTRY,
 
 	// Allow the directory depth to be configured (default 20)
 	if len(seen) > ntfs.MaxDirectoryDepth {
-		return []string{"<Err>",
-			"<Error-DirTooDeep>"}, TooDeepError
+		return []string{"<Err>", "<DirTooDeep>"}, TooDeepError
 	}
 
 	// If the path components are already cached, return a copy.
@@ -98,13 +97,13 @@ func getComponents(ntfs *NTFSContext, mft_entry *MFT_ENTRY,
 	parent_mft_entry, err := ntfs.GetMFT(int64(parent_id))
 	if err != nil {
 		return []string{"<Err>",
-			fmt.Sprintf("<Error Parent %v (%v)>", parent_id, err),
+			fmt.Sprintf("<Parent %v (%v)>", parent_id, err),
 			display_name}, InvalidParentEntry
 	}
 
 	if parent_sequence_number != parent_mft_entry.Sequence_value() {
 		return []string{"<Err>",
-			fmt.Sprintf("<Error Parent %v-%v need %v>", parent_id,
+			fmt.Sprintf("<Parent %v-%v need %v>", parent_id,
 				parent_mft_entry.Sequence_value(), parent_sequence_number),
 			display_name}, InvalidParentEntry
 	}

--- a/tests/usn_with_two_vcns/fixtures/stat.golden
+++ b/tests/usn_with_two_vcns/fixtures/stat.golden
@@ -1,6 +1,7 @@
 {
-  "FullPath": "/$UsnJrnl",
+  "FullPath": "/\u003cErr\u003e/\u003cError Parent 11 (EntryTooShortError)\u003e/$UsnJrnl",
   "MFTID": 68310,
+  "SequenceNumber": 2,
   "Size": 6352113880,
   "Allocated": true,
   "IsDir": false,
@@ -19,7 +20,9 @@
      "AccessedTime": "2017-06-15T01:05:51.5053972Z"
     },
     "Type": "POSIX",
-    "Name": "$UsnJrnl"
+    "Name": "$UsnJrnl",
+    "ParentEntryNumber": 11,
+    "ParentSequenceNumber": 11
    }
   ],
   "Attributes": [

--- a/tests/usn_with_two_vcns/fixtures/stat.golden
+++ b/tests/usn_with_two_vcns/fixtures/stat.golden
@@ -1,5 +1,5 @@
 {
-  "FullPath": "/\u003cErr\u003e/\u003cError Parent 11 (EntryTooShortError)\u003e/$UsnJrnl",
+  "FullPath": "/\u003cErr\u003e/\u003cParent 11 (EntryTooShortError)\u003e/$UsnJrnl",
   "MFTID": 68310,
   "SequenceNumber": 2,
   "Size": 6352113880,


### PR DESCRIPTION
Sometimes when reconstructing MFT paths we hit errors (especially for unallocated entried). The previous code would just stop the path reconstruction at the point of error and since paths are built in reverse it would appear like the last valid directory is actually rooted at the top of the filesystem.

This change creates special "psuedo" directories where these paths can terminate making it clear that they are errors. We also add extra components describing the error of why we were unable to continue processing.