### PR TITLE
Match USN parent MFT sequence when reconstructing paths.

### DIFF
--- a/bin/stat.go
+++ b/bin/stat.go
@@ -26,6 +26,9 @@ var (
 	stat_command_arg = stat_command.Arg(
 		"path", "The path to list or an STAT entry.",
 	).Default("5").String()
+
+	stat_command_verbose = stat_command.Flag(
+		"include_short_names", "Include Short Names in links").Bool()
 )
 
 func doSTAT() {
@@ -36,6 +39,14 @@ func doSTAT() {
 
 	ntfs_ctx, err := parser.GetNTFSContext(reader, 0)
 	kingpin.FatalIfError(err, "Can not open filesystem")
+
+	if *stat_command_verbose {
+		ntfs_ctx.SetOptions(parser.Options{
+			IncludeShortNames: true,
+			MaxLinks:          1000,
+			MaxDirectoryDepth: 100,
+		})
+	}
 
 	mft_entry, err := GetMFTEntry(ntfs_ctx, *stat_command_arg)
 	kingpin.FatalIfError(err, "Can not open path")

--- a/parser/model.go
+++ b/parser/model.go
@@ -112,7 +112,7 @@ func ModelMFTEntry(ntfs *NTFSContext, mft_entry *MFT_ENTRY) (*NTFSFileInformatio
 		})
 	}
 
-	for _, l := range GetHardLinks(ntfs, uint64(mft_id), 20) {
+	for _, l := range GetHardLinks(ntfs, uint64(mft_id), DefaultMaxLinks) {
 		result.Hardlinks = append(result.Hardlinks, strings.Join(l, "\\"))
 	}
 

--- a/parser/options.go
+++ b/parser/options.go
@@ -1,0 +1,24 @@
+package parser
+
+const (
+	DefaultMaxLinks = 0
+)
+
+type Options struct {
+	// Include short names in Link analysis
+	IncludeShortNames bool
+
+	// Max number of links to retrieve
+	MaxLinks int
+
+	// Maximum directory depth to anlayze for paths.
+	MaxDirectoryDepth int
+}
+
+func GetDefaultOptions() Options {
+	return Options{
+		IncludeShortNames: false,
+		MaxLinks:          20,
+		MaxDirectoryDepth: 20,
+	}
+}


### PR DESCRIPTION
Also enable optional short file name analysis and options to be set on ntfs context