### PR TITLE
Allow a prefix to be specified in the NTFS Options.

### DIFF
--- a/parser/hardlinks.go
+++ b/parser/hardlinks.go
@@ -29,6 +29,7 @@ type Visitor struct {
 	Max   int
 
 	IncludeShortNames bool
+	Prefix            []string
 }
 
 func (self *Visitor) Add(idx int, depth int) int {
@@ -45,8 +46,10 @@ func (self *Visitor) Components() [][]string {
 
 	for _, p := range self.Paths {
 		ReverseStringSlice(p)
+		components := append([]string{}, self.Prefix...)
+		components = append(components, p...)
 		if len(p) > 0 {
-			result = append(result, p)
+			result = append(result, components)
 		}
 	}
 	return result
@@ -62,6 +65,7 @@ func GetHardLinks(ntfs *NTFSContext, mft_id uint64, max int) [][]string {
 		Paths:             [][]string{[]string{}},
 		Max:               max,
 		IncludeShortNames: ntfs.options.IncludeShortNames,
+		Prefix:            ntfs.options.PrefixComponents,
 	}
 
 	mft_entry_summary, err := ntfs.GetMFTSummary(mft_id)

--- a/parser/mft.go
+++ b/parser/mft.go
@@ -391,6 +391,9 @@ func (self *MFTHighlight) FileName() string {
 	return short_name
 }
 
+// For simplicity and backwards compatibility returns the first hard
+// link of the mft entry. In NTFS MFT entries can have multiple paths
+// so you should consult the Links() to get more info.
 func (self *MFTHighlight) Components() []string {
 	components := []string{}
 	links := GetHardLinks(self.ntfs_ctx, uint64(self.EntryNumber), 1)

--- a/parser/options.go
+++ b/parser/options.go
@@ -13,6 +13,10 @@ type Options struct {
 
 	// Maximum directory depth to anlayze for paths.
 	MaxDirectoryDepth int
+
+	// These path components will be added in front of each link
+	// generated.
+	PrefixComponents []string
 }
 
 func GetDefaultOptions() Options {

--- a/parser/usn.go
+++ b/parser/usn.go
@@ -110,7 +110,7 @@ func (self *USN_RECORD) Links() []string {
 
 // Resolve the file to a full path
 func (self *USN_RECORD) FullPath() string {
-	// Since this record could have mean a file deletion event
+	// Since this record could have meant a file deletion event
 	// then resolving the actual MFT entry to a full path is less
 	// reliable. It is more reliable to resolve the parent path,
 	// and then add the USN record name to it.


### PR DESCRIPTION
This is helpful when prepending the drive letter to calculated paths.