### PR TITLE
Fixed bug in large MFT support.

### DIFF
--- a/bin/check.go
+++ b/bin/check.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"www.velocidex.com/golang/go-ntfs/parser"
+)
+
+var (
+	check_command = app.Command(
+		"check", "Check for some sanity.")
+
+	check_command_file_arg = check_command.Arg(
+		"file", "The image file to inspect",
+	).Required().File()
+
+	check_command_image_offset = check_command.Flag(
+		"image_offset", "The offset in the image to use.",
+	).Int64()
+
+	check_command_start_id = check_command.Flag(
+		"start", "The ID to start with").Int64()
+)
+
+func doCheck() {
+	reader, _ := parser.NewPagedReader(&parser.OffsetReader{
+		Offset: *check_command_image_offset,
+		Reader: getReader(*check_command_file_arg),
+	}, 1024, 10000)
+
+	ntfs_ctx, err := parser.GetNTFSContext(reader, 0)
+	kingpin.FatalIfError(err, "Can not open filesystem")
+
+	fmt.Printf(ntfs_ctx.RootMFT.DebugString())
+
+	number_of_entries := int64(ntfs_ctx.RootMFT.Size()) / ntfs_ctx.RecordSize
+	number_of_entries = 1000000000
+
+	for i := *check_command_start_id; i < number_of_entries; i++ {
+		reportError(ntfs_ctx, i)
+
+		mft_entry, err := ntfs_ctx.GetMFT(i)
+		if err != nil {
+			fmt.Printf("Error: %v: %v\n", i, err)
+			continue
+		}
+
+		stats := parser.Stat(ntfs_ctx, mft_entry)
+		if len(stats) == 0 {
+			continue
+		}
+
+		if i%100 == 0 {
+			fmt.Printf("Getting id %v - %v %v\n", i, mft_entry.Record_number(),
+				stats[0].Name)
+		}
+
+		if mft_entry.Record_number() != uint32(i) {
+			panic(i)
+		}
+	}
+}
+
+func reportError(ntfs_ctx *parser.NTFSContext, id int64) {
+	offset := ntfs_ctx.GetRecordSize() * id
+	disk_offset := parser.VtoP(ntfs_ctx.RootMFT.Reader, offset)
+	fmt.Printf("MFTId %v: Offset %v (%v clusters), disk offset %v (%v clusters)\n",
+		id, offset, offset/ntfs_ctx.ClusterSize,
+		disk_offset, disk_offset/ntfs_ctx.ClusterSize)
+}
+
+func init() {
+	command_handlers = append(command_handlers, func(command string) bool {
+		switch command {
+		case "check":
+			doCheck()
+		default:
+			return false
+		}
+		return true
+	})
+}

--- a/bin/check.go
+++ b/bin/check.go
@@ -21,6 +21,9 @@ var (
 
 	check_command_start_id = check_command.Flag(
 		"start", "The ID to start with").Int64()
+
+	check_command_end_id = check_command.Flag(
+		"end", "The ID to end with").Default("10000000").Int64()
 )
 
 func doCheck() {
@@ -32,12 +35,7 @@ func doCheck() {
 	ntfs_ctx, err := parser.GetNTFSContext(reader, 0)
 	kingpin.FatalIfError(err, "Can not open filesystem")
 
-	fmt.Printf(ntfs_ctx.RootMFT.DebugString())
-
-	number_of_entries := int64(ntfs_ctx.RootMFT.Size()) / ntfs_ctx.RecordSize
-	number_of_entries = 1000000000
-
-	for i := *check_command_start_id; i < number_of_entries; i++ {
+	for i := *check_command_start_id; i < *check_command_end_id; i++ {
 		reportError(ntfs_ctx, i)
 
 		mft_entry, err := ntfs_ctx.GetMFT(i)
@@ -64,7 +62,7 @@ func doCheck() {
 
 func reportError(ntfs_ctx *parser.NTFSContext, id int64) {
 	offset := ntfs_ctx.GetRecordSize() * id
-	disk_offset := parser.VtoP(ntfs_ctx.RootMFT.Reader, offset)
+	disk_offset := parser.VtoP(ntfs_ctx.MFTReader, offset)
 	fmt.Printf("MFTId %v: Offset %v (%v clusters), disk offset %v (%v clusters)\n",
 		id, offset, offset/ntfs_ctx.ClusterSize,
 		disk_offset, disk_offset/ntfs_ctx.ClusterSize)

--- a/bin/runs.go
+++ b/bin/runs.go
@@ -73,8 +73,8 @@ func doRuns() {
 		uint64(attr_type), uint16(attr_id))
 	kingpin.FatalIfError(err, "Can not open stream")
 
-	for _, r := range parser.DebugRuns(data, 0) {
-		fmt.Printf("%v\n", r)
+	for idx, r := range parser.DebugRuns(data, 0) {
+		fmt.Printf("%d %v\n", idx, r)
 	}
 }
 

--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -746,8 +746,7 @@ func (self *ATTRIBUTE_LIST_ENTRY) Attributes(
 		// entry than the one we are working on now. We need
 		// to fetch it from there.
 		mft_ref := attr_list_entry.MftReference()
-		if ntfs.RootMFT != nil &&
-			mft_ref != uint64(mft_entry.Record_number()) {
+		if mft_ref != uint64(mft_entry.Record_number()) {
 
 			DebugPrint("While working on %v - Fetching from MFT Entry %v\n",
 				mft_entry.Record_number(), mft_ref)

--- a/parser/debug.go
+++ b/parser/debug.go
@@ -136,10 +136,15 @@ func VtoP(reader interface{}, offset int64) int64 {
 
 type FixedUpReader struct {
 	*bytes.Reader
+	original_offset int64
 }
 
 func (self FixedUpReader) IsFixed(offset int64) bool {
 	return true
+}
+
+func (self FixedUpReader) VtoP(offset int64) int64 {
+	return self.original_offset
 }
 
 type IsFixedReader interface {

--- a/parser/debug.go
+++ b/parser/debug.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -74,6 +75,8 @@ func SetDebug() {
 	NTFS_DEBUG = &yes
 }
 
+func DlvBreak() {}
+
 func DebugPrint(fmt_str string, v ...interface{}) {
 	if NTFS_DEBUG == nil {
 		// os.Environ() seems very expensive in Go so we cache
@@ -113,4 +116,42 @@ func debugHexDump(buf []byte) string {
 		return hex.Dump(buf)
 	}
 	return ""
+}
+
+// A reader may be able to tell us about the physical layer it is
+// reading from.
+type VtoPer interface {
+	VtoP(offset int64) int64
+}
+
+func VtoP(reader interface{}, offset int64) int64 {
+	vtop, ok := reader.(VtoPer)
+	if ok {
+		return vtop.VtoP(offset)
+	}
+
+	fmt.Printf("Reader of type %T does not support VtoP\n", reader)
+	return 0
+}
+
+type FixedUpReader struct {
+	*bytes.Reader
+}
+
+func (self FixedUpReader) IsFixed(offset int64) bool {
+	return true
+}
+
+type IsFixedReader interface {
+	IsFixed(offset int64) bool
+}
+
+func IsFixed(item interface{}, offset int64) bool {
+	x, ok := item.(IsFixedReader)
+	if ok {
+		return x.IsFixed(offset)
+	}
+
+	fmt.Printf("Reader of type %T does not support IsFixed\n", item)
+	return false
 }

--- a/parser/easy.go
+++ b/parser/easy.go
@@ -52,7 +52,7 @@ func GetNTFSContext(image io.ReaderAt, offset int64) (*NTFSContext, error) {
 		return nil, err
 	}
 
-	ntfs.RootMFT = ntfs.Profile.MFT_ENTRY(mft_reader, 5)
+	ntfs.RootMFT = ntfs.Profile.MFT_ENTRY(mft_reader, 0)
 
 	return ntfs, nil
 }

--- a/parser/easy.go
+++ b/parser/easy.go
@@ -52,7 +52,7 @@ func GetNTFSContext(image io.ReaderAt, offset int64) (*NTFSContext, error) {
 		return nil, err
 	}
 
-	ntfs.RootMFT = ntfs.Profile.MFT_ENTRY(mft_reader, 0)
+	ntfs.MFTReader = mft_reader
 
 	return ntfs, nil
 }

--- a/parser/mft.go
+++ b/parser/mft.go
@@ -438,12 +438,11 @@ func ParseMFTFileWithOptions(
 		ntfs := newNTFSContext(&NullReader{}, "NullReader")
 		defer ntfs.Close()
 
-		ntfs.RootMFT = &MFT_ENTRY{Reader: reader, Profile: ntfs.Profile}
+		ntfs.MFTReader = reader
 		ntfs.ClusterSize = cluster_size
 		ntfs.RecordSize = record_size
 		ntfs.SetOptions(options)
 
-		ntfs.RootMFT = ntfs.Profile.MFT_ENTRY(reader, 0)
 		for id := int64(0); id < size/record_size+1; id++ {
 			mft_entry, err := ntfs.GetMFT(id)
 			if err != nil {

--- a/parser/reader.go
+++ b/parser/reader.go
@@ -23,6 +23,14 @@ type PagedReader struct {
 	Miss int64
 }
 
+func (self *PagedReader) IsFixed(offset int64) bool {
+	return false
+}
+
+func (self *PagedReader) VtoP(offset int64) int64 {
+	return offset
+}
+
 func (self *PagedReader) ReadAt(buf []byte, offset int64) (int, error) {
 	self.mu.Lock()
 	defer self.mu.Unlock()

--- a/parser/runs.go
+++ b/parser/runs.go
@@ -1,6 +1,8 @@
 package parser
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type RunInfo struct {
 	Type             string
@@ -37,9 +39,9 @@ func (self RunInfo) String() string {
 func DebugRawRuns(runs []*Run) {
 	fmt.Printf("Runs ....\n")
 
-	for _, r := range runs {
-		fmt.Printf("Disk Offset %d  RelativeUrnOffset %d (Length %d)\n",
-			r.Offset, r.RelativeUrnOffset, r.Length)
+	for idx, r := range runs {
+		fmt.Printf("%d Disk Offset %d  RelativeUrnOffset %d (Length %d)\n",
+			idx, r.Offset, r.RelativeUrnOffset, r.Length)
 	}
 }
 

--- a/tests/large_file_small_init/fixtures/runs.golden
+++ b/tests/large_file_small_init/fixtures/runs.golden
@@ -3,6 +3,6 @@ Creating cache of size 10000
 Cache miss for 0 (400) (0)
 Cache miss for c0000000 (400) (1)
 Cache miss for c000b800 (400) (2)
- 0 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 4096,  Cluster 1) Delegate *parser.RangeReader
-  1 MappedReader: FileOffset 0 -> DiskOffset 69787 (Length 256,  Cluster 4096) Delegate *parser.PagedReader
- 0 MappedReader: FileOffset 4096 -> DiskOffset 0 (Length 1044480, Sparse  Cluster 1) Delegate *parser.NullReader
+0  0 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 4096,  Cluster 1) Delegate *parser.RangeReader
+1   1 MappedReader: FileOffset 0 -> DiskOffset 69787 (Length 256,  Cluster 4096) Delegate *parser.PagedReader
+2  0 MappedReader: FileOffset 4096 -> DiskOffset 0 (Length 1044480, Sparse  Cluster 1) Delegate *parser.NullReader

--- a/tests/usn_with_two_vcns/fixtures/runs.golden
+++ b/tests/usn_with_two_vcns/fixtures/runs.golden
@@ -88,49 +88,49 @@ Found   struct NTFS_ATTRIBUTE @ 0x38:
   MftReference: 0x10ad6
   Attribute_id: 0x8e
 
- 0 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 6352113880,  Cluster 1) Delegate *parser.RangeReader
-  1 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 44544, Sparse  Cluster 4096) Delegate *parser.NullReader
-  1 MappedReader: FileOffset 44544 -> DiskOffset 0 (Length 1496432, Sparse  Cluster 4096) Delegate *parser.NullReader
-  1 MappedReader: FileOffset 1540976 -> DiskOffset 6815248 (Length 16,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1540992 -> DiskOffset 1247560 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541152 -> DiskOffset 1397172 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541280 -> DiskOffset 4832524 (Length 176,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541456 -> DiskOffset 10366380 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541584 -> DiskOffset 10620074 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541712 -> DiskOffset 8441520 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541840 -> DiskOffset 8455164 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1541968 -> DiskOffset 10161476 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542096 -> DiskOffset 11824283 (Length 320,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542416 -> DiskOffset 10305592 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542544 -> DiskOffset 7170396 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542672 -> DiskOffset 8668822 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542800 -> DiskOffset 8455020 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1542928 -> DiskOffset 9333842 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543056 -> DiskOffset 7332290 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543184 -> DiskOffset 11242485 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543312 -> DiskOffset 8486600 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543472 -> DiskOffset 7776836 (Length 96,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543568 -> DiskOffset 4039352 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543696 -> DiskOffset 4032904 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543824 -> DiskOffset 3844536 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1543952 -> DiskOffset 3725528 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544080 -> DiskOffset 4504800 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544240 -> DiskOffset 9370577 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544368 -> DiskOffset 7757580 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544496 -> DiskOffset 7300285 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544624 -> DiskOffset 4375191 (Length 304,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1544928 -> DiskOffset 11393496 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1545056 -> DiskOffset 4826968 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1545184 -> DiskOffset 3946604 (Length 1280,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1546464 -> DiskOffset 11469896 (Length 144,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1546608 -> DiskOffset 11331662 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1546736 -> DiskOffset 4445308 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1546864 -> DiskOffset 3998421 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1546992 -> DiskOffset 4097876 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547120 -> DiskOffset 4793156 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547248 -> DiskOffset 5117240 (Length 112,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547360 -> DiskOffset 4838210 (Length 96,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547456 -> DiskOffset 4122104 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547584 -> DiskOffset 3145508 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547712 -> DiskOffset 2706080 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
-  1 MappedReader: FileOffset 1547840 -> DiskOffset 1073741824 (Length 16, Sparse  Cluster 4096) Delegate *parser.NullReader
+0  0 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 6352113880,  Cluster 1) Delegate *parser.RangeReader
+1   1 MappedReader: FileOffset 0 -> DiskOffset 0 (Length 44544, Sparse  Cluster 4096) Delegate *parser.NullReader
+2   1 MappedReader: FileOffset 44544 -> DiskOffset 0 (Length 1496432, Sparse  Cluster 4096) Delegate *parser.NullReader
+3   1 MappedReader: FileOffset 1540976 -> DiskOffset 6815248 (Length 16,  Cluster 4096) Delegate *parser.PagedReader
+4   1 MappedReader: FileOffset 1540992 -> DiskOffset 1247560 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
+5   1 MappedReader: FileOffset 1541152 -> DiskOffset 1397172 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+6   1 MappedReader: FileOffset 1541280 -> DiskOffset 4832524 (Length 176,  Cluster 4096) Delegate *parser.PagedReader
+7   1 MappedReader: FileOffset 1541456 -> DiskOffset 10366380 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+8   1 MappedReader: FileOffset 1541584 -> DiskOffset 10620074 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+9   1 MappedReader: FileOffset 1541712 -> DiskOffset 8441520 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+10   1 MappedReader: FileOffset 1541840 -> DiskOffset 8455164 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+11   1 MappedReader: FileOffset 1541968 -> DiskOffset 10161476 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+12   1 MappedReader: FileOffset 1542096 -> DiskOffset 11824283 (Length 320,  Cluster 4096) Delegate *parser.PagedReader
+13   1 MappedReader: FileOffset 1542416 -> DiskOffset 10305592 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+14   1 MappedReader: FileOffset 1542544 -> DiskOffset 7170396 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+15   1 MappedReader: FileOffset 1542672 -> DiskOffset 8668822 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+16   1 MappedReader: FileOffset 1542800 -> DiskOffset 8455020 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+17   1 MappedReader: FileOffset 1542928 -> DiskOffset 9333842 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+18   1 MappedReader: FileOffset 1543056 -> DiskOffset 7332290 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+19   1 MappedReader: FileOffset 1543184 -> DiskOffset 11242485 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+20   1 MappedReader: FileOffset 1543312 -> DiskOffset 8486600 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
+21   1 MappedReader: FileOffset 1543472 -> DiskOffset 7776836 (Length 96,  Cluster 4096) Delegate *parser.PagedReader
+22   1 MappedReader: FileOffset 1543568 -> DiskOffset 4039352 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+23   1 MappedReader: FileOffset 1543696 -> DiskOffset 4032904 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+24   1 MappedReader: FileOffset 1543824 -> DiskOffset 3844536 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+25   1 MappedReader: FileOffset 1543952 -> DiskOffset 3725528 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+26   1 MappedReader: FileOffset 1544080 -> DiskOffset 4504800 (Length 160,  Cluster 4096) Delegate *parser.PagedReader
+27   1 MappedReader: FileOffset 1544240 -> DiskOffset 9370577 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+28   1 MappedReader: FileOffset 1544368 -> DiskOffset 7757580 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+29   1 MappedReader: FileOffset 1544496 -> DiskOffset 7300285 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+30   1 MappedReader: FileOffset 1544624 -> DiskOffset 4375191 (Length 304,  Cluster 4096) Delegate *parser.PagedReader
+31   1 MappedReader: FileOffset 1544928 -> DiskOffset 11393496 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+32   1 MappedReader: FileOffset 1545056 -> DiskOffset 4826968 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+33   1 MappedReader: FileOffset 1545184 -> DiskOffset 3946604 (Length 1280,  Cluster 4096) Delegate *parser.PagedReader
+34   1 MappedReader: FileOffset 1546464 -> DiskOffset 11469896 (Length 144,  Cluster 4096) Delegate *parser.PagedReader
+35   1 MappedReader: FileOffset 1546608 -> DiskOffset 11331662 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+36   1 MappedReader: FileOffset 1546736 -> DiskOffset 4445308 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+37   1 MappedReader: FileOffset 1546864 -> DiskOffset 3998421 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+38   1 MappedReader: FileOffset 1546992 -> DiskOffset 4097876 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+39   1 MappedReader: FileOffset 1547120 -> DiskOffset 4793156 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+40   1 MappedReader: FileOffset 1547248 -> DiskOffset 5117240 (Length 112,  Cluster 4096) Delegate *parser.PagedReader
+41   1 MappedReader: FileOffset 1547360 -> DiskOffset 4838210 (Length 96,  Cluster 4096) Delegate *parser.PagedReader
+42   1 MappedReader: FileOffset 1547456 -> DiskOffset 4122104 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+43   1 MappedReader: FileOffset 1547584 -> DiskOffset 3145508 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+44   1 MappedReader: FileOffset 1547712 -> DiskOffset 2706080 (Length 128,  Cluster 4096) Delegate *parser.PagedReader
+45   1 MappedReader: FileOffset 1547840 -> DiskOffset 1073741824 (Length 16, Sparse  Cluster 4096) Delegate *parser.NullReader


### PR DESCRIPTION
When the MFT is too large to fix in one entry, the second $DATA stream
VCN is stored in another MFT entry and an ATTRIBUTE_LIST points to
it. There was a bug where the second VCN was added without applying
suitable fixups and therefore the runlist was sometimes corrupted.

This PR adds more debugging and visibility to allow tracking the
physical sector on the disk where a file resides. There is also a
"check" command added to run a host of sanity checks. Currently we check
that the MFT ID we try to open is the same one we receive.