### PR TITLE
Fix incorrect dir detection

### DIFF
--- a/parser/easy.go
+++ b/parser/easy.go
@@ -138,10 +138,10 @@ func Stat(ntfs *NTFSContext, node_mft *MFT_ENTRY) []*FileInfo {
 	var data_attributes []*NTFS_ATTRIBUTE
 	var win32_name *FILE_NAME
 	var index_attribute *NTFS_ATTRIBUTE
-	var is_dir bool
 	var fn_birth_time, fn_mtime time.Time
 
 	mft_id := node_mft.Record_number()
+	is_dir := node_mft.Flags().IsSet("DIRECTORY")
 
 	// Walk all the attributes collecting the imporant things.
 	for _, attr := range node_mft.EnumerateAttributes(ntfs) {
@@ -179,7 +179,6 @@ func Stat(ntfs *NTFSContext, node_mft *MFT_ENTRY) []*FileInfo {
 			data_attributes = append(data_attributes, attr)
 
 		case ATTR_TYPE_INDEX_ROOT, ATTR_TYPE_INDEX_ALLOCATION:
-			is_dir = true
 			index_attribute = attr
 		}
 	}


### PR DESCRIPTION
For some unknown reason, the `Stat()` function in easy.go was not using the MFT header flag to determine if an entry represents a directory. Instead it was setting an entry to be a directory if it had an INDEX_ROOT or INDEX_ALLOCATION attribute, which is not guaranteed to be correct. Usually the INDEX_* entries are $I30 streams, but not always, such as in the case of $SDS file (which does not have $I30 streams but has $SDH and $SDI streams which are INDEX_* type).

This has now been fixed to just use the MFT header flag, which is the definitive source. With this change, the Velociraptor project will no longer need special treatment for fetching $SDS files, ie, no need for Windows.Triage.SDS.