### PR TITLE
Only decode sparse runs for sparse files.

### DIFF
--- a/bin/live.go
+++ b/bin/live.go
@@ -98,10 +98,12 @@ func doLiveTest() {
 			fmt.Printf("ERROR Getting MFT Id: %v\n", err)
 		}
 
-		reader, err := parser.OpenStream(ntfs_ctx, mft_entry, 128, 0, "")
+		reader, err := parser.OpenStream(ntfs_ctx, mft_entry, 128,
+			parser.WILDCARD_STREAM_ID, "")
 		if err != nil {
 			fmt.Printf("ERROR Getting MFT Id %v: %v\n",
 				mft_entry.Record_number(), err)
+			continue
 		}
 
 		ntfs_h := sha256.New()

--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -353,7 +353,8 @@ func (self *RangeReader) DebugString() string {
 func NewUncompressedRangeReader(
 	runs []*Run,
 	cluster_size int64,
-	disk_reader io.ReaderAt) *RangeReader {
+	disk_reader io.ReaderAt,
+	is_sparse bool) *RangeReader {
 
 	result := &RangeReader{}
 	var file_offset int64
@@ -378,7 +379,7 @@ func NewUncompressedRangeReader(
 
 		// If the run is sparse we make it read from the null
 		// reader.
-		if run.RelativeUrnOffset == 0 {
+		if is_sparse && run.RelativeUrnOffset == 0 {
 			reader_run.IsSparse = true
 			reader_run.Reader = &NullReader{}
 		}

--- a/parser/easy.go
+++ b/parser/easy.go
@@ -533,7 +533,7 @@ func joinAllVCNs(ntfs *NTFSContext, vcns []*NTFS_ATTRIBUTE) []*MappedReader {
 			FileOffset:  0,
 			Length:      initialized_size,
 			Reader: NewUncompressedRangeReader(runs,
-				ntfs.ClusterSize, ntfs.DiskReader),
+				ntfs.ClusterSize, ntfs.DiskReader, IsSparse(flags)),
 		}
 	}
 


### PR DESCRIPTION
This avoids considering $Boot as sparse.