### PR TITLE
Refactor path resolution to allow preloading of MFTEntrySummary

### DIFF
--- a/bin/usn.go
+++ b/bin/usn.go
@@ -68,7 +68,11 @@ func doUSN() {
 	filename_filter, err := regexp.Compile(*usn_command_filename_filter)
 	kingpin.FatalIfError(err, "Filename filter")
 
-	for record := range parser.ParseUSN(context.Background(), ntfs_ctx, 0) {
+	usn_stream, err := parser.OpenUSNStream(ntfs_ctx)
+	kingpin.FatalIfError(err, "OpenUSNStream")
+
+	for record := range parser.ParseUSN(context.Background(),
+		ntfs_ctx, usn_stream, 0) {
 		mft_id := record.FileReferenceNumberID()
 		mft_seq := uint16(record.FileReferenceNumberSequence())
 
@@ -92,7 +96,8 @@ func doUSN() {
 			})
 	}
 
-	for record := range parser.ParseUSN(context.Background(), ntfs_ctx, 0) {
+	for record := range parser.ParseUSN(
+		context.Background(), ntfs_ctx, usn_stream, 0) {
 		filename := record.Filename()
 
 		if !filename_filter.MatchString(filename) {

--- a/parser/caching.go
+++ b/parser/caching.go
@@ -23,20 +23,79 @@ type MFTEntryCache struct {
 	ntfs *NTFSContext
 
 	lru *LRU
+
+	preloaded map[uint64]*MFTEntrySummary
 }
 
 func NewMFTEntryCache(ntfs *NTFSContext) *MFTEntryCache {
 	lru, _ := NewLRU(10000, nil, "MFTEntryCache")
 	return &MFTEntryCache{
-		ntfs: ntfs,
-		lru:  lru,
+		ntfs:      ntfs,
+		lru:       lru,
+		preloaded: make(map[uint64]*MFTEntrySummary),
 	}
 }
 
-func (self *MFTEntryCache) GetSummary(id uint64) (*MFTEntrySummary, error) {
+// This function is used to preset persisted information in the cache
+// about known MFT entries from other sources than the MFT itself. In
+// particular, the USN journal is often a source of additional
+// historical information. When resolving an MFT entry summary, we
+// first look to the MFT itself, however if the sequence number does
+// not match the required entry, we look toh the preloaded entry for a
+// better match.
+//
+// The allows us to substitute historical information (from the USN
+// journal) while resolving full paths.
+func (self *MFTEntryCache) SetPreload(id uint64, seq uint16,
+	cb func(entry *MFTEntrySummary) (*MFTEntrySummary, bool)) {
+	key := id | uint64(seq)<<48
+
+	// Optionally allow the callback to update the preloaded entry.
+	entry, _ := self.preloaded[key]
+	new_entry, updated := cb(entry)
+	if updated {
+		self.preloaded[key] = new_entry
+	}
+}
+
+// GetSummary gets a MFTEntrySummary for the mft id. The sequence
+// number is a hint for the required sequence of the entry. This
+// function may return an MFTEntrySummary with a different sequence
+// than requested.
+func (self *MFTEntryCache) GetSummary(
+	id uint64, seq uint16) (*MFTEntrySummary, error) {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
+	// We prefer to get the read entry from the MFT because it has all
+	// the short names etc.
+	res, err := self._GetSummary(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the MFT entry is not correct (does not have the required
+	// sequence number), we check the preloaded set for an approximate
+	// match.
+	if res.Sequence != seq {
+		// Try to get from the preloaded records
+		key := id | uint64(seq)<<48
+		res, ok := self.preloaded[key]
+		if ok {
+			// Yep - the sequence number of correct.
+			return res, nil
+		}
+
+		// Just return the incorrect entry - callers can add an error
+		// for incorrect sequence number.
+	}
+
+	return res, nil
+}
+
+// Get the summary from the underlying MFT itself.
+func (self *MFTEntryCache) _GetSummary(
+	id uint64) (*MFTEntrySummary, error) {
 	res_any, pres := self.lru.Get(int(id))
 	if pres {
 		res, ok := res_any.(*MFTEntrySummary)

--- a/parser/easy.go
+++ b/parser/easy.go
@@ -465,8 +465,12 @@ func findNextVCN(attributes []*attrInfo, selected_attribute *attrInfo) (*attrInf
 // all related attributes and wraps them in a RangeReader to appear as
 // a single stream. This function is what you need when you want to
 // read the full file.
-func OpenStream(ntfs *NTFSContext,
-	mft_entry *MFT_ENTRY, attr_type uint64, attr_id uint16, attr_name string) (RangeReaderAt, error) {
+func OpenStream(
+	ntfs *NTFSContext,
+	mft_entry *MFT_ENTRY,
+	attr_type uint64,
+	attr_id uint16,
+	attr_name string) (RangeReaderAt, error) {
 
 	result := &RangeReader{}
 

--- a/parser/mft.go
+++ b/parser/mft.go
@@ -371,7 +371,8 @@ func (self *MFTHighlight) FullPath() string {
 }
 
 func (self *MFTHighlight) Links() []string {
-	components := GetHardLinks(self.ntfs_ctx, uint64(self.EntryNumber),
+	components := self.ntfs_ctx.full_path_resolver.GetHardLinks(
+		uint64(self.EntryNumber), self.SequenceNumber,
 		DefaultMaxLinks)
 	result := make([]string, 0, len(components))
 	for _, l := range components {
@@ -404,7 +405,8 @@ func (self *MFTHighlight) FileName() string {
 // so you should consult the Links() to get more info.
 func (self *MFTHighlight) Components() []string {
 	components := []string{}
-	links := GetHardLinks(self.ntfs_ctx, uint64(self.EntryNumber), 1)
+	links := self.ntfs_ctx.full_path_resolver.GetHardLinks(
+		uint64(self.EntryNumber), self.SequenceNumber, 1)
 	if len(links) > 0 {
 		components = links[0]
 	}

--- a/parser/model.go
+++ b/parser/model.go
@@ -116,7 +116,8 @@ func ModelMFTEntry(ntfs *NTFSContext, mft_entry *MFT_ENTRY) (*NTFSFileInformatio
 		})
 	}
 
-	for _, l := range GetHardLinks(ntfs, uint64(mft_id), DefaultMaxLinks) {
+	for _, l := range ntfs.full_path_resolver.GetHardLinks(
+		uint64(mft_id), result.SequenceNumber, DefaultMaxLinks) {
 		result.Hardlinks = append(result.Hardlinks, strings.Join(l, "\\"))
 	}
 

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -23,7 +23,8 @@ func get_display_name(file_names []*FILE_NAME) string {
 // Traverse the mft entry and attempt to find its owner until the
 // root. We return the full path of the MFT entry.
 func GetFullPath(ntfs *NTFSContext, mft_entry *MFT_ENTRY) string {
-	links := GetHardLinks(ntfs, uint64(mft_entry.Record_number()), 1)
+	links := ntfs.full_path_resolver.GetHardLinks(
+		uint64(mft_entry.Record_number()), mft_entry.Sequence_value(), 1)
 	if len(links) == 0 {
 		return "/"
 	}


### PR DESCRIPTION
When reconstructing USN journal paths we actually have access to more information than contained in the MFT because the USN journal records partial filename information. This PR adds the ability to preload these partial file information in case they are encounterd during path reconstruction.

See https://cybercx.com.au/blog/ntfs-usnjrnl-rewind/ for more details.