### PR TITLE
Fix: n is not used in case of io.EOF

### DIFF
--- a/parser/attribute.go
+++ b/parser/attribute.go
@@ -693,7 +693,7 @@ func (self *RangeReader) ReadAt(buf []byte, file_offset int64) (
 			run_offset := int(file_offset - run_file_offset)
 
 			n, err := self.readFromARun(j, buf[buf_idx:], run_offset)
-			if err != nil {
+			if err != nil && err != io.EOF {
 				DebugPrint("Reading offset %v from run %v returned error %v\n",
 					run_offset, self.runs[j].DebugString(), err)
 				return buf_idx, err


### PR DESCRIPTION
When a partial read occurs and io.EOF is returned, the file_offset or buf_idx does not advance. This appears to cause errors such as issue #71 in go-ntfs. It would be great if you could check this.