### PR TITLE
Changed semantics of the reader again

### DIFF
--- a/parser/boot.go
+++ b/parser/boot.go
@@ -51,7 +51,7 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 
 	buffer := make([]byte, allocated_len)
 	n, err := mft.Reader.ReadAt(buffer, mft.Offset)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	if n < int(allocated_len) {
@@ -69,7 +69,7 @@ func FixUpDiskMFTEntry(mft *MFT_ENTRY) (io.ReaderAt, error) {
 	fixup_table_len := CapInt64(fixup_count*2, int64(allocated_len))
 	fixup_table := make([]byte, fixup_table_len)
 	n, err = mft.Reader.ReadAt(fixup_table, fixup_offset)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	if n < int(fixup_table_len) {

--- a/parser/handwritten.go
+++ b/parser/handwritten.go
@@ -25,7 +25,7 @@ func NewNTFS_ATTRIBUTE(Reader io.ReaderAt,
 	}
 
 	_, err := Reader.ReadAt(result.b[:], Offset)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return result
 	}
 	return result

--- a/parser/usn.go
+++ b/parser/usn.go
@@ -61,7 +61,7 @@ func (self *USN_RECORD) Next(max_offset int64) *USN_RECORD {
 		data := make([]byte, CapInt64(to_read, MAX_USN_RECORD_SCAN_SIZE))
 
 		n, err := self.Reader.ReadAt(data, offset)
-		if err != nil || n == 0 {
+		if n == 0 || (err != nil && !errors.Is(err, io.EOF)) {
 			return nil
 		}
 


### PR DESCRIPTION
Previous EOF semantic is not workable because an err != nil is still given even though there is valid data forcing callers to distinguish between err != nil && err != EOF to specifically rule out EOF as an actual error.

The new semantics are:
1. Reading anywhere within the file (even if the buffer falls outside the file) will return n = len(buf) and err = 0

2. reading outside the bounds of the file will return n=0 and err = EOF